### PR TITLE
Added O_BINARY to correct glue for compile FNT

### DIFF
--- a/Tools/glue/font.c
+++ b/Tools/glue/font.c
@@ -193,7 +193,7 @@ FontWrite(void	    *base,  	/* Base of file buffer */
 #if defined(__HIGHC__)
     i = open(outfile, O_BINARY|O_WRONLY|O_CREAT, S_IREAD | S_IWRITE);
 #else
-    i = open(outfile, O_WRONLY|O_CREAT, 0666);
+    i = open(outfile, O_BINARY|O_WRONLY|O_CREAT, 0666);
 #endif
     if (i < 0) {
 	perror(outfile);


### PR DESCRIPTION
Added O_BINARY to  correct glue for compile FNT from source.
Hint from @Falk.